### PR TITLE
ブログ記事詳細ページの title が反映されるように設定

### DIFF
--- a/src/pages/posts/[id].vue
+++ b/src/pages/posts/[id].vue
@@ -7,7 +7,7 @@ const { data } = useFetch(`/api/posts/postData?id=${encodeURIComponent(id)}`, {
   key: id,
 });
 
-const postTitle = data.value?.title;
+const postTitle = data.value?.title ?? 'ushironoko.me';
 
 const description = data.value?.contentHtml
   .match(/^\<p\>.*\<\/p\>/g)
@@ -16,7 +16,7 @@ const description = data.value?.contentHtml
   .replace('</p>', '');
 
 useHead({
-  title: postTitle ?? 'ushironoko.me',
+  title: postTitle,
   meta: [
     {
       name: 'twitter:card',
@@ -28,7 +28,7 @@ useHead({
     },
     {
       name: 'twitter:title',
-      content: postTitle ?? 'ushironoko.me',
+      content: postTitle,
     },
     {
       name: 'twitter:image',
@@ -58,11 +58,11 @@ useHead({
     },
     {
       property: 'og:title',
-      content: postTitle ?? 'ushironoko.me',
+      content: postTitle,
     },
     {
       property: 'og:site_name',
-      content: postTitle ?? 'ushironoko.me',
+      content: postTitle,
     },
     {
       property: 'og:url',

--- a/src/pages/posts/[id].vue
+++ b/src/pages/posts/[id].vue
@@ -28,7 +28,7 @@ useHead({
     },
     {
       name: 'twitter:title',
-      content: data.value?.title ?? 'ushironoko.me',
+      content: postTitle ?? 'ushironoko.me',
     },
     {
       name: 'twitter:image',
@@ -58,11 +58,11 @@ useHead({
     },
     {
       property: 'og:title',
-      content: data.value?.title ?? 'ushironoko.me',
+      content: postTitle ?? 'ushironoko.me',
     },
     {
       property: 'og:site_name',
-      content: data.value?.title ?? 'ushironoko.me',
+      content: postTitle ?? 'ushironoko.me',
     },
     {
       property: 'og:url',

--- a/src/pages/posts/[id].vue
+++ b/src/pages/posts/[id].vue
@@ -62,7 +62,7 @@ useHead({
     },
     {
       property: 'og:site_name',
-      content: postTitle,
+      content: 'ushironoko.me',
     },
     {
       property: 'og:url',

--- a/src/pages/posts/[id].vue
+++ b/src/pages/posts/[id].vue
@@ -7,6 +7,8 @@ const { data } = useFetch(`/api/posts/postData?id=${encodeURIComponent(id)}`, {
   key: id,
 });
 
+const postTitle = data.value?.title;
+
 const description = data.value?.contentHtml
   .match(/^\<p\>.*\<\/p\>/g)
   ?.toString()
@@ -14,6 +16,7 @@ const description = data.value?.contentHtml
   .replace('</p>', '');
 
 useHead({
+  title: postTitle ?? 'ushironoko.me',
   meta: [
     {
       name: 'twitter:card',


### PR DESCRIPTION
<table>
  <tr>
    <th>変更前
    <th>変更後
  </tr>
  <tr>
    <td><img width="1177" alt="「Vue3でtsx firstができるか検証する」記事の title 要素が「ushironoko.me」となっている" src="https://user-images.githubusercontent.com/1996642/230246887-09beb2a7-f28a-4699-a26e-97e305021928.png">
    <td><img width="1199" alt="「Vue3でtsx firstができるか検証する」記事の title 要素が「Vue3でtsx firstができるか検証する」となっている" src="https://user-images.githubusercontent.com/1996642/230246891-5abf1f99-509b-48fe-9e05-e5c96d142662.png">
  </tr>
</table>
