### PR TITLE
ダークモードで読みづらいのでツイッターのカラーにします。いいですね

### DIFF
--- a/src/assets/css/global.css
+++ b/src/assets/css/global.css
@@ -1,5 +1,5 @@
 html {
-  @apply dark:bg-black dark:text-white;
+  @apply dark:bg-[#15202B] dark:text-[rgb(247,249,249)];
 }
 
 ul {


### PR DESCRIPTION
# 問題

- ダークモードで背景#000、テキスト#fff だと読むのがしんどい

# 対策

- 淡い色にする（ツイッターが好きなのでツイッターのダークブルーの色にします）

## before

![image](https://user-images.githubusercontent.com/1443118/230273667-478a8088-3a33-4514-98bf-9b8264dff333.png)

## after
![image](https://user-images.githubusercontent.com/1443118/230273681-62781445-a68e-49d2-aef6-0c17c2cd7072.png)
