### PR TITLE
`overflow-wrap: break-word;` と和解せよ

### DIFF
--- a/src/assets/css/global.css
+++ b/src/assets/css/global.css
@@ -22,6 +22,7 @@ pre {
   font-size: 18px;
   letter-spacing: 0.04em;
   line-height: 36px;
+  overflow-wrap: break-word;
 }
 
 h2 {


### PR DESCRIPTION
<table>
<tr>
	<th> 現在
	<th> <code>overflow-wrap: break-word;</code>適応後
</tr>
<tr>
  <td><img width="300" alt="Screen Shot 2023-04-06 at 19 33 09" src="https://user-images.githubusercontent.com/1996642/230352480-97bbe166-6c46-4acd-843e-6903d7d3b4d0.png">
  <td><img width="300" alt="Screen Shot 2023-04-06 at 19 33 16" src="https://user-images.githubusercontent.com/1996642/230352498-b7ce341a-703b-44c7-b53d-1fed539439e3.png">
</tr>
</table>

長い英字が入ると画面スクロールが発生したり正しい文字サイズではなくなるため、いい感じで改行してくれる設定を追加しました。
