### PR TITLE
`text-decoration: underline` を指定してリンク文字列の存在を明確にしたい

### DIFF
--- a/src/assets/css/global.css
+++ b/src/assets/css/global.css
@@ -46,9 +46,10 @@ pre {
 p > a {
   color: #000;
   @apply dark:text-white;
-  text-decoration: underline;
   border-bottom: 1px black dotted;
-  @apply border-b border-dotted border-white;
+  @apply border-b border-dotted;
+  @apply border-black;
+  @apply dark:border-white;
   background-color: transparent;
   -webkit-text-decoration-skip: objects;
 }

--- a/src/assets/css/global.css
+++ b/src/assets/css/global.css
@@ -46,7 +46,7 @@ pre {
 p > a {
   color: #000;
   @apply dark:text-white;
-  text-decoration: none;
+  text-decoration: underline;
   border-bottom: 1px black dotted;
   @apply border-b border-dotted border-white;
   background-color: transparent;


### PR DESCRIPTION
<table>
<tr>
	<td><code>text-decoration: none</code>
	<td><code>text-decoration: underline</code>
<tr>
	<td><img width="660" alt="text-decoration: noneを指定したままのリンク文字列" src="https://user-images.githubusercontent.com/1996642/230700223-28c2fc4d-839c-48dc-89a1-5726f5bc1af3.png">
	<td><img width="638" alt="text-decoration: underlineを指定した状態のリンク文字列" src="https://user-images.githubusercontent.com/1996642/230700224-9300d1a1-b11e-4c41-9420-4640cfdf7b7a.png">
</table>

URL がリンクになっている場合となってない場合があったので、リンク文字列の場合は存在を明確にしておきたい